### PR TITLE
fix(settings): resolve crash from useSearchParams misuse

### DIFF
--- a/src/app/settings/page.js
+++ b/src/app/settings/page.js
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
+import { useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/layouts/DashboardLayout";
 import { withAuth, useAuth } from "@/context/AuthContext";
 import apiClient from "@/lib/apiClient";
@@ -27,18 +28,18 @@ function SettingsPage() {
 
     // Redirect feedback (e.g. ?connected=calendar)
     const [globalMessage, setGlobalMessage] = useState(null);
+    const searchParams = useSearchParams();
     useEffect(() => {
-        const params = useSearchParams();
-        if (params.get("connected") === "calendar") {
+        if (searchParams.get("connected") === "calendar") {
             setGlobalMessage({ type: "success", text: "Google Calendar connected!" });
             setActiveTab("Connected Services");
             window.history.replaceState({}, "", "/settings");
-        } else if (params.get("error") === "calendar_auth_failed") {
+        } else if (searchParams.get("error") === "calendar_auth_failed") {
             setGlobalMessage({ type: "error", text: "Google Calendar connection failed. Please try again." });
             setActiveTab("Connected Services");
             window.history.replaceState({}, "", "/settings");
         }
-    }, []);
+    }, [searchParams]);
 
     // AI settings state
     const [aiSettings, setAISettings] = useState(null);
@@ -508,4 +509,13 @@ function SettingsPage() {
     );
 }
 
-export default withAuth(SettingsPage);
+// useSearchParams() must be wrapped in a Suspense boundary in the App Router.
+function SettingsPageWithSuspense() {
+    return (
+        <Suspense fallback={null}>
+            <SettingsPage />
+        </Suspense>
+    );
+}
+
+export default withAuth(SettingsPageWithSuspense);


### PR DESCRIPTION
## Summary

The **Settings page crashed on every load** with:

```
ReferenceError: useSearchParams is not defined
    at SettingsPage.useEffect (src/app/settings/page.js:31)
```

Two problems in the redirect-feedback effect:

1. `useSearchParams` was **never imported** from `next/navigation`.
2. It was **called inside `useEffect`**, which violates React's Rules of Hooks (hooks must run at the top level of the component, not inside callbacks/effects).

## Fix

- Import `useSearchParams` from `next/navigation`.
- Call `useSearchParams()` at the top level of the component and read the params inside the effect (with `searchParams` as a dependency).
- Wrap the page in a `<Suspense>` boundary, as the App Router requires for `useSearchParams` (matches the existing pattern in `src/app/search/page.js`).

## Verification

Ran the dev server and loaded the page in a headless browser with a mocked backend:

- `/settings` now renders fully (Profile, Linked Accounts / Notifications / AI / Schedule / Connected Services tabs) instead of crashing.
- `/settings?connected=calendar` correctly shows the green **"Google Calendar connected!"** banner and auto-switches to the **Connected Services** tab — the exact behavior the original (broken) code was trying to implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kbi3DZfs9imnUt63b9BfjY)_